### PR TITLE
Add osusergo build tag as an alternative to !cgo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![Build Status](https://travis-ci.org/tweekmonster/luser.svg?branch=master)](https://travis-ci.org/tweekmonster/luser)
 
 `luser` is a drop-in replacement for `os/user` which allows you to lookup users
-and groups in cross-compiled builds without `cgo`.
+and groups in cross-compiled builds without `cgo`. It also works with `cgo`
+builds which use the all Go version of `os/user` via the `osusergo` build tag.
 
 
 ## Overview
@@ -42,6 +43,8 @@ fallback results on your platform:
 
 ```shell
 $ CGO_ENABLED=0 go install github.com/tweekmonster/luser/cmd/luser
+# Or in a cgo build with the all Go version of os/user
+$ go install -tags=osusergo github.com/tweekmonster/luser/cmd/luser
 $ luser -c
 $ luser username
 $ luser 1000

--- a/current_cgo.go
+++ b/current_cgo.go
@@ -1,5 +1,5 @@
 // +build !windows
-// +build cgo
+// +build cgo,!osusergo
 
 package luser
 

--- a/current_default.go
+++ b/current_default.go
@@ -1,5 +1,5 @@
 // +build !windows
-// +build !cgo
+// +build !cgo osusergo
 
 package luser
 


### PR DESCRIPTION
Go 1.11, https://golang.org/doc/go1.11, added a build tag osusergo which
allows using the all go implementation of os/user even when compiling
with cgo. This is useful if you progrom depends on a C library, but you
still want a static build.